### PR TITLE
Plugin customization syntax corrected (reprise)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Customize which SVGO [plugins](https://github.com/svg/svgo/tree/master/plugins) 
 
 ```js
 var imagemin = new Imagemin()
-	.use(svgo({ plugins: [{ removeViewBox: false, removeEmptyAttrs: false }] }));
+	.use(svgo({ plugins: [{ removeViewBox: false }, { removeEmptyAttrs: false }] }));
 ```
 
 


### PR DESCRIPTION
I think the plugins options expects an array of objects, not an array containing one single object. 

(I tested locally, but please check you too)
