### PR TITLE
Output file size checking removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,7 @@ module.exports = function (opts) {
 				res.data = res.data.replace(/&(?!amp;)/g, '&amp;');
 				res.data = new Buffer(res.data);
 
-				if (res.data.length < file.contents.length) {
-					file.contents = res.data;
-				}
+				file.contents = res.data;
 			});
 		} catch (err) {
 			err.fileName = file.path;


### PR DESCRIPTION
I had some problem when I use some SVGO plugins which increases the size of out svg file. By design it is correct behavior, but it might be wrong.
When svg file already optimized and I try add some custom SVGO plugins to create uniq IDs for example, output file will be the same as input file.