### PR TITLE
Remove entity-escaping of ampersands

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = opts => buf => {
 				return;
 			}
 
-			resolve(new Buffer(res.data.replace(/&(?!amp;)/g, '&amp;')));
+			resolve(new Buffer(res.data));
 		});
 	});
 };


### PR DESCRIPTION
Remove entity-escaping of ampersand ('&') characters which results in incorrect svgo input + output.