### PR TITLE
Keep backwards compatibility with node 4 LTS

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = opts => buf => {
 				return;
 			}
 
-			resolve(Buffer.from(res.data));
+			resolve(new Buffer(res.data)); // eslint-disable-line unicorn/no-new-buffer
 		});
 	});
 };


### PR DESCRIPTION
@twjacobsen @jarnaiz are totally right in #25, node 4 should be supported for [a year longer](https://github.com/nodejs/LTS#lts-schedule), even though `new Buffer()` is now deprecated.