### PR TITLE
Fix No 'main' or 'exports' DeprecationWarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"license": "MIT",
 	"repository": "imagemin/imagemin-svgo",
 	"type": "module",
+	"main":"index.js",
 	"funding": {
 		"url": "https://github.com/sindresorhus/imagemin-svgo?sponsor=1"
 	},


### PR DESCRIPTION
Fixes #52 

```"main":"index.js"```

Simply adds the above line to `package.json` to resolve the following error:

```
(node:63922) [DEP0151] DeprecationWarning: No "main" or "exports" field defined in the package.json for /Users/phil/dev/frontend-boilerplate/node_modules/imagemin-svgo/ resolving the main entry point "index.js", imported from /Users/phil/dev/frontend-boilerplate/gulpfile.js.
Default "index" lookups for the main are deprecated for ES modules.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

I should have raised this PR two weeks ago, apologies